### PR TITLE
Shader material

### DIFF
--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -1,9 +1,12 @@
+import { ShaderMaterial } from 'three'
+import { propsValues, defaultFragmentShader, defaultVertexShader } from '../tools.js';
+
 export default {
   inject: ['three', 'mesh'],
   props: {
     uniforms: Object,
-    vertexShader: String,
-    fragmentShader: String,
+    vertexShader: { type: String, default: defaultVertexShader },
+    fragmentShader: { type: String, default: defaultFragmentShader },
   },
   created() {
     this.createMaterial();
@@ -12,6 +15,11 @@ export default {
   },
   unmounted() {
     this.material.dispose();
+  },
+  methods: {
+    createMaterial() {
+      this.material = new ShaderMaterial(propsValues(this.$props));
+    },
   },
   render() {
     return [];

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -1,10 +1,11 @@
 import { ShaderMaterial } from 'three'
+import { watch } from 'vue';
 import { propsValues, defaultFragmentShader, defaultVertexShader } from '../tools.js';
 
 export default {
   inject: ['three', 'mesh'],
   props: {
-    uniforms: Object,
+    uniforms: { type: Object, default: () => { } },
     vertexShader: { type: String, default: defaultVertexShader },
     fragmentShader: { type: String, default: defaultFragmentShader },
   },
@@ -19,6 +20,16 @@ export default {
   methods: {
     createMaterial() {
       this.material = new ShaderMaterial(propsValues(this.$props));
+    },
+    addWatchers() {
+      ['uniforms', 'vertexShader', 'fragmentShader'].forEach(p => {
+        watch(() => this[p], (value) => {
+          this.material[p] = value;
+        },
+          // only watch deep on uniforms
+          { deep: p === 'uniforms' }
+        );
+      });
     },
   },
   render() {

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -25,6 +25,12 @@ export default {
       ['uniforms', 'vertexShader', 'fragmentShader'].forEach(p => {
         watch(() => this[p], (value) => {
           this.material[p] = value;
+
+          if (p === 'vertexShader' || p === 'fragmentShader') {
+            // recreate material if we change either shader
+            this.material.dispose();
+            this.createMaterial();
+          }
         },
           // only watch deep on uniforms
           { deep: p === 'uniforms' }

--- a/src/materials/index.js
+++ b/src/materials/index.js
@@ -3,10 +3,10 @@ export { default as LambertMaterial } from './LambertMaterial.js';
 export { default as MatcapMaterial } from './MatcapMaterial.js';
 export { default as PhongMaterial } from './PhongMaterial.js';
 export { default as PhysicalMaterial } from './PhysicalMaterial.js';
+export { default as ShaderMaterial } from './ShaderMaterial.js';
 export { default as StandardMaterial } from './StandardMaterial.js';
 export { default as SubSurfaceMaterial } from './SubSurfaceMaterial.js';
 export { default as ToonMaterial } from './ToonMaterial.js';
-
 
 export { default as Texture } from './Texture.js';
 export { default as CubeTexture } from './CubeTexture.js';

--- a/src/tools.js
+++ b/src/tools.js
@@ -73,3 +73,19 @@ function getMatcapFormatString(format) {
       return '';
   }
 }
+
+// shader defaults
+export const defaultVertexShader = `
+varying vec2 vUv;
+
+void main(){
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+}`;
+
+export const defaultFragmentShader = `
+varying vec2 vUv;
+
+void main() {
+  gl_FragColor = vec4(vUv.x, vUv.y, 0., 1.0);
+}`;


### PR DESCRIPTION
Shader material now works with a default vertex + fragment shader. Also supports custom vertex + fragment shaders, as while as dynamic uniforms:

Template:
```html
<Box>
  <!-- default fragment shader colors vertex based on UV position -->
  <ShaderMaterial/>
</Box>

<Box>
  <!-- flashing red cube using animated uniforms -->
  <ShaderMaterial
    :uniforms="uniforms"
    :fragment-shader="fragmentShader"
  />
</Box>
```

Script
```js
data(){
  return {
    uniforms: { uColor: { value: 0 } },
    fragmentShader: `uniform float uColor; void main(){ gl_FragColor = vec4(uColor, 0., 0., 1.);}`
  }
},
mounted(){
  this.update()
},
methods: {
  update(){
    this.uniforms.uColor.value = Math.abs(Math.sin(Date.now() * 0.001))
    requestAnimationFrame(this.update)
  }
}
```

I'd like to be able to do this kind of thing too:

```html
<ShaderMaterial>
  <script type="shader/fragment">
    void main() { /* ... */ }
  </script>
  <script type="shader/vertex">
    void main() { /* ... */ }
  </script>
</ShaderMaterial>
```

but wanted to run that by you first, since `shader/fragment` and `shader/vertex` may not be the best labels for those. (They fall under the "any other value" rule [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type), but I wanted to see what you thought of that functionality and those type names.) Thanks so much!