### PR TITLE
Shader texture proof of concept

### DIFF
--- a/src/materials/CubeTexture.js
+++ b/src/materials/CubeTexture.js
@@ -13,7 +13,7 @@ export default {
     onLoad: Function,
     onProgress: Function,
     onError: Function,
-    id: { type: String, default: 'envMap' },
+    name: { type: String, default: 'envMap' },
     refraction: Boolean,
     // todo: remove ?
     refractionRatio: { type: Number, default: 0.98 },
@@ -24,7 +24,7 @@ export default {
     watch(() => this.urls, this.refreshTexture);
   },
   unmounted() {
-    this.material.setTexture(null, this.id);
+    this.material.setTexture(null, this.name);
     this.texture.dispose();
   },
   methods: {
@@ -35,7 +35,7 @@ export default {
     },
     refreshTexture() {
       this.createTexture();
-      this.material.setTexture(this.texture, this.id);
+      this.material.setTexture(this.texture, this.name);
       if (this.refraction) {
         this.texture.mapping = CubeRefractionMapping;
         this.material.setProp('refractionRatio', this.refractionRatio);

--- a/src/materials/ShaderMaterial.js
+++ b/src/materials/ShaderMaterial.js
@@ -9,6 +9,11 @@ export default {
     vertexShader: { type: String, default: defaultVertexShader },
     fragmentShader: { type: String, default: defaultFragmentShader },
   },
+  provide() {
+    return {
+      material: this,
+    };
+  },
   created() {
     this.createMaterial();
     ['vertexShader', 'fragmentShader'].forEach(p => {
@@ -29,7 +34,7 @@ export default {
     },
   },
   render() {
-    return [];
+    return this.$slots.default ? this.$slots.default() : [];
   },
   __hmrId: 'ShaderMaterial',
 };

--- a/src/materials/Texture.js
+++ b/src/materials/Texture.js
@@ -6,7 +6,8 @@ export default {
   inject: ['material'],
   emits: ['loaded'],
   props: {
-    id: { type: String, default: 'map' },
+    name: { type: String, default: 'map' },
+    uniform: { type: String, default: null },
     src: String,
     onLoad: Function,
     onProgress: Function,
@@ -25,7 +26,7 @@ export default {
     watch(() => this.src, this.refreshTexture);
   },
   unmounted() {
-    if (this.material && this.material.setTexture) this.material.setTexture(null, this.id);
+    if (this.material && this.material.setTexture) this.material.setTexture(null, this.name);
     this.texture.dispose();
   },
   methods: {
@@ -38,10 +39,16 @@ export default {
     },
     refreshTexture() {
       this.createTexture();
-      if (this.material && this.material.setTexture) { this.material.setTexture(this.texture, this.id); }
+      // handle standard material
+      if (this.material && this.material.setTexture) { this.material.setTexture(this.texture, this.name); }
+      // handle shader material
       else if (this.material && this.material.material.type === "ShaderMaterial") {
-        const id = this.id === 'map' ? this.src.replace(/\..*/, '') : this.id;
-        this.material.uniforms[id] = { value: this.texture };
+        // require a `uniform` prop so we know what to call the uniform
+        if (!this.uniform) {
+          console.warn('"uniform" prop required to use texture in a shader.')
+          return
+        }
+        this.material.uniforms[this.uniform] = { value: this.texture };
       }
     },
     onLoaded() {

--- a/src/materials/Texture.js
+++ b/src/materials/Texture.js
@@ -25,7 +25,7 @@ export default {
     watch(() => this.src, this.refreshTexture);
   },
   unmounted() {
-    this.material.setTexture(null, this.id);
+    if (this.material && this.material.setTexture) this.material.setTexture(null, this.id);
     this.texture.dispose();
   },
   methods: {
@@ -38,7 +38,11 @@ export default {
     },
     refreshTexture() {
       this.createTexture();
-      this.material.setTexture(this.texture, this.id);
+      if (this.material && this.material.setTexture) { this.material.setTexture(this.texture, this.id); }
+      else if (this.material && this.material.material.type === "ShaderMaterial") {
+        const id = this.id === 'map' ? this.src.replace(/\..*/, '') : this.id;
+        this.material.uniforms[id] = { value: this.texture };
+      }
     },
     onLoaded() {
       if (this.onLoad) this.onLoad();


### PR DESCRIPTION
I ran into a situation where I didn't want to prep an entire `TextureLoader` for a shader texture manually, so I tried this out and it seems to work nicely - it needs a little more polish but I'd love to know your thoughts.

Basically, instead of providing a texture to a shader in its uniforms:

```html
<ShaderMaterial :uniforms="uniforms"/>
```

```js
// need to import TextureLoader
// need to declare uniforms
// need to run this in mounted or other function:
this.uniforms.texture = { value: new TextureLoader().load('pathToTexture.png') }
```

you can use this PR to provide a texture to a shader in the markup, just like a normal TroisJS material:

```html
<ShaderMaterial>
  <Texture src="pathToTexture.png"/>
</ShaderMaterial>

<!-- no JS necessary! -->
```

From there, the shader has access to a `sampler2D` uniform called `pathToTexture` (the value of the texture's `src` attribute, minus the extension). You can also specify the uniform name by setting the ID:

```html
<ShaderMaterial>
  <Texture src="pathToTexture.png" id="myCustomTextureName"/>
</ShaderMaterial>
```
In this case the uniform would be called `myCustomTextureName`.

The code in here isn't ready for pull just yet - I'd want to build a more robust regex replacer for the default uniform name, or maybe just throw an error if there isn't an `id` provided and get rid of the default name functionality entirely. Let me know any thoughts @klevron !