### PR TITLE
ready event added to object3d

### DIFF
--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -4,6 +4,7 @@ import { bindProp } from '../tools.js';
 export default {
   name: 'Object3D',
   inject: ['three', 'scene', 'rendererComponent'],
+  emits: ['ready'],
   props: {
     position: { type: Object, default: { x: 0, y: 0, z: 0 } },
     rotation: { type: Object, default: { x: 0, y: 0, z: 0 } },
@@ -37,6 +38,8 @@ export default {
         parent = parent.$parent;
       }
       if (!this._parent) console.error('Missing parent (Scene, Group...)');
+
+      this.$emit('ready', this);
     },
     add(o) { this.o3d.add(o); },
     remove(o) { this.o3d.remove(o); },

--- a/src/core/Object3D.js
+++ b/src/core/Object3D.js
@@ -38,8 +38,7 @@ export default {
         parent = parent.$parent;
       }
       if (!this._parent) console.error('Missing parent (Scene, Group...)');
-
-      this.$emit('ready', this);
+      else this.$emit('ready', this);
     },
     add(o) { this.o3d.add(o); },
     remove(o) { this.o3d.remove(o); },


### PR DESCRIPTION
Object3Ds emit a `ready` event when placed in the scene. This enables direct access to the object once it has been inserted in the scene - for example, we can replace

```html
<Box ref="box"/>
```

```js
export default {
  mounted(){
    console.log(this.$refs.box.mesh)
  }
}
```

with:

```html
<Box @ready="boxReady"/>
```

```js
export default {
  methods: {
    boxReady(box){
       // full contents of the Box Object3D received as param, so we can do something like:
      const { mesh, material } = box
    }
  }
}
```

This has the added benefit of providing a clean fix for #25, since the `ready` event only fires once the Object3D is in the scene. 

It might be worth thinking through more events for objects and materials - maybe a `beforeInsert`, `inserted`, `onSetGeometry`, `onSetMaterial`? Thoughts @klevron ?