### PR TITLE
added ssao pass

### DIFF
--- a/src/effects/BokehPass.js
+++ b/src/effects/BokehPass.js
@@ -37,8 +37,7 @@ export default {
       height: this.three.size.height,
     };
     const pass = new BokehPass(this.three.scene, this.three.camera, params);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'BokehPass',
 };

--- a/src/effects/EffectPass.js
+++ b/src/effects/EffectPass.js
@@ -1,5 +1,6 @@
 export default {
   inject: ['three', 'passes'],
+  events: ['ready'],
   beforeMount() {
     if (!this.passes) {
       console.error('Missing parent EffectComposer');
@@ -7,6 +8,13 @@ export default {
   },
   unmounted() {
     if (this.pass.dispose) this.pass.dispose();
+  },
+  methods: {
+    completePass(pass) {
+      this.passes.push(pass);
+      this.pass = pass;
+      this.$emit('ready', pass);
+    }
   },
   render() {
     return [];

--- a/src/effects/FXAAPass.js
+++ b/src/effects/FXAAPass.js
@@ -6,8 +6,7 @@ export default {
   extends: EffectPass,
   mounted() {
     const pass = new ShaderPass(FXAAShader);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
 
     // resize will be called in three init
     this.three.onAfterResize(this.resize);

--- a/src/effects/FilmPass.js
+++ b/src/effects/FilmPass.js
@@ -29,8 +29,7 @@ export default {
   },
   mounted() {
     const pass = new FilmPass(this.noiseIntensity, this.scanlinesIntensity, this.scanlinesCount, this.grayscale);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'FilmPass',
 };

--- a/src/effects/HalftonePass.js
+++ b/src/effects/HalftonePass.js
@@ -22,8 +22,7 @@ export default {
       });
     });
 
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'HalftonePass',
 };

--- a/src/effects/RenderPass.js
+++ b/src/effects/RenderPass.js
@@ -11,8 +11,7 @@ export default {
       console.error('Missing Camera');
     }
     const pass = new RenderPass(this.three.scene, this.three.camera);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'RenderPass',
 };

--- a/src/effects/SMAAPass.js
+++ b/src/effects/SMAAPass.js
@@ -6,8 +6,7 @@ export default {
   mounted() {
     // three size is not set yet, but this pass will be resized by effect composer
     const pass = new SMAAPass(this.three.size.width, this.three.size.height);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'SMAAPass',
 };

--- a/src/effects/SSAOPass.js
+++ b/src/effects/SSAOPass.js
@@ -36,5 +36,5 @@ export default {
       this.pass.height = this.three.size.height
     },
   },
-  __hmrId: 'FXAAPass',
+  __hmrId: 'SSAOPass',
 };

--- a/src/effects/SSAOPass.js
+++ b/src/effects/SSAOPass.js
@@ -1,0 +1,40 @@
+import { SSAOPass } from 'three/examples/jsm/postprocessing/SSAOPass.js';
+import EffectPass from './EffectPass.js';
+
+export default {
+  extends: EffectPass,
+  props: {
+    scene: null,
+    camera: null,
+    options: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  mounted() {
+    const pass = new SSAOPass(
+      this.scene || this.three.scene,
+      this.camera || this.three.camera,
+      this.three.size.width,
+      this.three.size.height
+    );
+    this.passes.push(pass);
+    this.pass = pass;
+
+    for (let key of Object.keys(this.options)) {
+      this.pass[key] = this.options[key];
+    }
+    // resize will be called in three init
+    this.three.onAfterResize(this.resize);
+  },
+  unmounted() {
+    this.three.offAfterResize(this.resize);
+  },
+  methods: {
+    resize() {
+      this.pass.width = this.three.size.width
+      this.pass.height = this.three.size.height
+    },
+  },
+  __hmrId: 'FXAAPass',
+};

--- a/src/effects/SSAOPass.js
+++ b/src/effects/SSAOPass.js
@@ -18,8 +18,7 @@ export default {
       this.three.size.width,
       this.three.size.height
     );
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
 
     for (let key of Object.keys(this.options)) {
       this.pass[key] = this.options[key];

--- a/src/effects/TiltShiftPass.js
+++ b/src/effects/TiltShiftPass.js
@@ -40,8 +40,9 @@ export default {
       uniforms.texSize.value.set(width, height);
     };
 
-    this.completePass(pass);
-    this.completePass(pass1);
+    // emit ready event with two passes - do so manually in this file instead
+    // of calling `completePass` like in other effect types
+    this.$emit('ready', [this.pass, this.pass1])
   },
   methods: {
     updateFocusLine() {

--- a/src/effects/TiltShiftPass.js
+++ b/src/effects/TiltShiftPass.js
@@ -39,6 +39,9 @@ export default {
     this.pass.setSize = (width, height) => {
       uniforms.texSize.value.set(width, height);
     };
+
+    this.completePass(pass);
+    this.completePass(pass1);
   },
   methods: {
     updateFocusLine() {

--- a/src/effects/UnrealBloomPass.js
+++ b/src/effects/UnrealBloomPass.js
@@ -17,8 +17,7 @@ export default {
   mounted() {
     const size = new Vector2(this.three.size.width, this.three.size.height);
     const pass = new UnrealBloomPass(size, this.strength, this.radius, this.threshold);
-    this.passes.push(pass);
-    this.pass = pass;
+    this.completePass(pass);
   },
   __hmrId: 'UnrealBloomPass',
 };

--- a/src/effects/ZoomBlurPass.js
+++ b/src/effects/ZoomBlurPass.js
@@ -10,12 +10,13 @@ export default {
     strength: { type: Number, default: 0.5 },
   },
   mounted() {
-    this.pass = new ShaderPass(ZoomBlur);
-    this.passes.push(this.pass);
+    const pass = new ShaderPass(ZoomBlur);
 
-    const uniforms = this.uniforms = this.pass.uniforms;
+    const uniforms = this.uniforms = pass.uniforms;
     bindProp(this, 'center', uniforms.center, 'value');
     bindProp(this, 'strength', uniforms.strength, 'value');
+
+    this.completePass(pass);
   },
   __hmrId: 'ZoomBlurPass',
 };

--- a/src/effects/index.js
+++ b/src/effects/index.js
@@ -6,6 +6,7 @@ export { default as FilmPass } from './FilmPass.js';
 export { default as FXAAPass } from './FXAAPass.js';
 export { default as HalftonePass } from './HalftonePass.js';
 export { default as SMAAPass } from './SMAAPass.js';
+export { default as SSAOPass } from './SSAOPass.js';
 export { default as TiltShiftPass } from './TiltShiftPass.js';
 export { default as UnrealBloomPass } from './UnrealBloomPass.js';
 export { default as ZoomBlurPass } from './ZoomBlurPass.js';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,6 +69,7 @@ export const TroisJSVuePlugin = {
       'RenderPass',
       'SAOPass',
       'SMAAPass',
+      'SSAOPass',
       'TiltShiftPass',
       'UnrealBloomPass',
       'ZoomBlurPass',


### PR DESCRIPTION
Added SSAO to postprocessing. Example:

```html
<EffectComposer>
  <RenderPass />
  <SSAOPass :options="{ kernelRadius: 0.2, maxDistance: 0.03 }" />
</EffectComposer>
```

SSAOPass has quite a few useful options (see [here](https://github.com/mrdoob/three.js/blob/master/examples/jsm/postprocessing/SSAOPass.js#L35-L52)) so the only props in this component are `scene` (optional), `camera` (optional), and `options`. It may be better to leave the options manually to the user by adding lifecycle methods - maybe something like:

```html
<SSAOPass @ready="prepSSAO"/>
```

```js
export default {
  methods: {
    prepSSAO(ssao){
      ssao.kernelRadius = 0.2
      ssao.maxRadius = 0.03
    }
  }
}
```

Any thoughts on this @klevron ? Thanks!