### PR TITLE
update cameras to extend base component and use render slot

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -1,0 +1,11 @@
+// import Object3D from '../core/Object3D.js';
+
+export default {
+  // TODO: eventually extend Object3D, for now: error 'injection "scene" not found'
+  // because camera is a sibling of scene in Trois
+  // extends: Object3D,
+  inject: ['three'],
+  render() {
+    return this.$slots.default ? this.$slots.default() : [];
+  },
+}

--- a/src/core/OrthographicCamera.js
+++ b/src/core/OrthographicCamera.js
@@ -1,8 +1,10 @@
 import { OrthographicCamera } from 'three';
 import { watch } from 'vue';
 import { bindProp } from '../tools.js';
+import Camera from './Camera.js';
 
 export default {
+  extends: Camera,
   name: 'OrthographicCamera',
   inject: ['three'],
   props: {
@@ -28,6 +30,5 @@ export default {
 
     this.three.camera = this.camera;
   },
-  render() { return []; },
   __hmrId: 'OrthographicCamera',
 };

--- a/src/core/PerspectiveCamera.js
+++ b/src/core/PerspectiveCamera.js
@@ -1,8 +1,10 @@
 import { PerspectiveCamera } from 'three';
 import { watch } from 'vue';
 import { bindProp } from '../tools.js';
+import Camera from './Camera.js';
 
 export default {
+  extends: Camera,
   name: 'PerspectiveCamera',
   inject: ['three'],
   props: {
@@ -29,6 +31,5 @@ export default {
 
     this.three.camera = this.camera;
   },
-  render() { return []; },
   __hmrId: 'PerspectiveCamera',
 };


### PR DESCRIPTION
Camera updates required by changes being made in #31 that I thought would be generally useful. This makes the cameras inherit from a base `Camera` component that includes a `render` function that renders the default slot. 

Eventually I'd like to make the camera inherit from Object3D since that's how it works in Three, but I'm getting an `injection "scene" not found` because the camera is a sibling of the scene in Trois, so we can worry about that later 😄 