### PR TITLE
rectarealight helper fix

### DIFF
--- a/src/lights/RectAreaLight.js
+++ b/src/lights/RectAreaLight.js
@@ -23,7 +23,7 @@ export default {
 
     if (this.helper) {
       this.lightHelper = new RectAreaLightHelper(this.light);
-      this.addToParent(this.lightHelper);
+      this.light.add(this.lightHelper);
     }
 
     this.initLight();


### PR DESCRIPTION
Per [the docs](https://threejs.org/docs/#examples/en/helpers/RectAreaLightHelper), the RectAreaLightHelper needs to be added as a child of the attached light to work, so this updates the helper creation code to set that up.