### PR TITLE
Fix build error

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,12 +18,10 @@ export default defineComponent({
   components: { Box, Camera, LambertMaterial, PointLight, Renderer, Scene },
   mounted() {
     const renderer = this.$refs.renderer as RendererPublicInterface
-    const box = this.$refs.box as MeshPublicInterface
-    if (renderer && box) {
+    const mesh = (this.$refs.box as MeshPublicInterface).mesh
+    if (renderer && mesh) {
       renderer.onBeforeRender(() => {
-        if (box.mesh){
-          box.mesh.rotation.x += 0.01
-        }
+        mesh.rotation.x += 0.01
       })
     }
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,9 @@ export default defineComponent({
     const box = this.$refs.box as MeshPublicInterface
     if (renderer && box) {
       renderer.onBeforeRender(() => {
-        box.mesh.rotation.x += 0.01
+        if (box.mesh){
+          box.mesh.rotation.x += 0.01
+        }
       })
     }
   },


### PR DESCRIPTION
Running `npm run build` throws an error since the box mesh might be defined - this fixes that error.