### PR TITLE
Metalness fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,9 @@ export default defineComponent({
     const box = this.$refs.box as MeshPublicInterface
     if (renderer && box) {
       renderer.onBeforeRender(() => {
-        box.mesh.rotation.x += 0.01
+        if (box.mesh){
+          box.mesh.rotation.x += 0.01
+        }
       })
     }
   },

--- a/src/core/Object3D.ts
+++ b/src/core/Object3D.ts
@@ -139,7 +139,7 @@ export default defineComponent({
         obj = this.o3d
       }
 
-      this.o3d.children.forEach((child) => {
+      obj.children.forEach((child) => {
         callback(child)
         this.allChildren(callback, child)
       })

--- a/src/core/Object3D.ts
+++ b/src/core/Object3D.ts
@@ -16,6 +16,7 @@ export interface Object3DInterface extends Object3DSetupInterface {
   removeFromParent(o?: Object3D): boolean
   add(o: Object3D): void
   remove(o: Object3D): void
+  allChildren(callback: Function, obj?: Object3D): void
 }
 
 export interface Object3DPublicInterface extends ComponentPublicInstance, Object3DInterface {}
@@ -124,6 +125,25 @@ export default defineComponent({
     },
     add(o: Object3D) { this.o3d?.add(o) },
     remove(o: Object3D) { this.o3d?.remove(o) },
+
+    /**
+     * Run a callback on all children in this object's hierarchy.
+     * @param callback Callback to run on all children.
+     * @param obj Optional initial object. Defaults to this object3D if left empty
+     * @returns 
+     */
+    allChildren(callback: Function, obj: Object3D | null = null) {
+      if (!this.o3d) return
+
+      if (obj === null) {
+        obj = this.o3d
+      }
+
+      this.o3d.children.forEach((child) => {
+        callback(child)
+        this.allChildren(callback, child)
+      })
+    }
   },
   render() {
     return this.$slots.default ? this.$slots.default() : []

--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,16 +1,51 @@
-import { Object3D as TObject3D } from 'three'
+import { Object3D as TObject3D, Group, Material, Mesh, MeshStandardMaterial } from 'three'
 import { defineComponent } from 'vue'
 import Object3D from '../core/Object3D'
+
+function isMesh(toCheck: TObject3D): toCheck is Mesh {
+  return toCheck.type === 'Mesh'
+}
+function isMeshStandardMaterial(
+  toCheck: Material
+): toCheck is MeshStandardMaterial {
+  return (toCheck as MeshStandardMaterial).metalness !== undefined
+}
 
 export default defineComponent({
   extends: Object3D,
   emits: ['load', 'progress', 'error'],
   props: {
     src: { type: String, required: true },
+    metalness: { type: [Boolean, Number], default: false }
   },
   data() {
     return {
       progress: 0,
+    }
+  },
+  mounted() {
+    // set all metalness to desired value
+    if (this.metalness !== false) {
+      // figure out target metalness (default = 0)
+      let targetMetalness = typeof this.metalness === 'boolean' ? 0 : this.metalness
+
+      // for all children in the hierarchy, set their metalness to desired value
+      // OR keep traversing down if childn is a group.
+      this.allChildren((child: Group | Mesh) => {
+        if (isMesh(child)) {
+          if (Array.isArray(child.material)) {
+            // handle multiple materials
+            child.material.forEach((mat) => {
+              if (isMeshStandardMaterial(mat)) {
+                mat.metalness = targetMetalness
+              }
+            })
+          } else if (isMeshStandardMaterial(child.material)) {
+            // handle single material
+            child.material.metalness = targetMetalness
+          }
+        }
+      })
     }
   },
   methods: {


### PR DESCRIPTION
When importing GLB models from [kenney.nl](https://kenney.nl/) (haven't tried any other sources yet), I'm noticing ambient lights have no effect. I did some digging and it turns out this is because the `metalness` on those models' materials is set to 1, which is a pain to need to fix each time I want to use one of these models.

This PR adds an `allChildren` method that runs on all descendants in an Object3D's hierarchy, then it uses that method to set metalness to 0 (default) or any number the user passes, like this:

```html
<!-- Sets all metalness to 0 - naive fix but immediately fixes AmbientLight issue -->
<GltfModel metalness/>

<!-- Sets all metalness to 0.5 -->
<GltfModel :metalness="0.5"/>
```

I think this is useful and lightweight enough to merge to the main branch - any thoughts @klevron ? Thanks!