### PR TITLE
fix: #67 add raycasting on gltf

### DIFF
--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -16,6 +16,15 @@ export default defineComponent({
   methods: {
     onLoad(model: TObject3D) {
       this.$emit('load', model)
+      if (this.onPointerEnter ||
+        this.onPointerOver ||
+        this.onPointerMove ||
+        this.onPointerLeave ||
+        this.onPointerDown ||
+        this.onPointerUp ||
+        this.onClick) {
+        if (this.renderer) this.renderer.three.addIntersectObject(model)
+      }
       this.initObject3D(model)
     },
     onProgress(progress: ProgressEvent) {


### PR DESCRIPTION
Adds the model to the `intersectObject` array to enable it for raycaster to find interactions.
closes https://github.com/troisjs/trois/issues/67