### PR TITLE
Set mesh initial velocity in cannonWorld

### DIFF
--- a/src/components/physics/useCannon.js
+++ b/src/components/physics/useCannon.js
@@ -116,7 +116,7 @@ export default function useCannon(options) {
       mesh.userData.velocity.y,
       mesh.userData.velocity.z) : new Vec3(0, 0, 0)
 
-    const body = new Body({ shape, position, quaternion, velocity, mass, linearDamping: damping, angularDamping: damping })
+    const body = new Body({ shape, position, velocity, quaternion, mass, linearDamping: damping, angularDamping: damping })
     world.addBody(body)
 
     mesh.userData.body = body

--- a/src/components/physics/useCannon.js
+++ b/src/components/physics/useCannon.js
@@ -111,7 +111,12 @@ export default function useCannon(options) {
     const mass = mesh.userData.mass ? mesh.userData.mass : 0
     const damping = mesh.userData.damping ? mesh.userData.damping : 0.01
 
-    const body = new Body({ shape, position, quaternion, mass, linearDamping: damping, angularDamping: damping })
+    const velocity = mesh.userData.velocity ? new Vec3(
+      mesh.userData.velocity.x,
+      mesh.userData.velocity.y,
+      mesh.userData.velocity.z) : new Vec3(0, 0, 0)
+
+    const body = new Body({ shape, position, quaternion, velocity, mass, linearDamping: damping, angularDamping: damping })
     world.addBody(body)
 
     mesh.userData.body = body


### PR DESCRIPTION
This allows the user to set initial velocity for mesh objects like how you set mass in cannonWorld. Now you can use something like `mesh.userData.velocity = {x: 100, y: 100 , z: 100}` inside a initializer method like `initMesh` inside`<Box @created="initMesh"> </Box>`. I'll probably come up with something similiar for InstancedMesh too.