### PR TITLE
Set InstancedMesh initial velocities in cannonWorld

### DIFF
--- a/src/components/physics/useCannon.js
+++ b/src/components/physics/useCannon.js
@@ -159,7 +159,17 @@ export default function useCannon(options) {
       if (mesh.userData.dampings?.[i]) damping = mesh.userData.dampings?.[i]
       else if (mesh.userData.damping) damping = mesh.userData.damping
 
-      const body = new Body({ shape, position, mass, linearDamping: damping, angularDamping: damping })
+      let velocity = new Vec3(0, 0, 0)
+      if (mesh.userData.velocities?.[i]) velocity = new Vec3(
+        mesh.userData.velocities?.[i].x,
+        mesh.userData.velocities?.[i].y,
+        mesh.userData.velocities?.[i].z)
+      else if (mesh.userData.velocities) velocity = new Vec3(
+        mesh.userData.velocities.x,
+        mesh.userData.velocities.y,
+        mesh.userData.velocities.z)
+
+      const body = new Body({ shape, position, velocity, mass, linearDamping: damping, angularDamping: damping })
       world.addBody(body)
       bodies.push(body)
     }


### PR DESCRIPTION
Same change as #106 except for instancedmesh. Through `userData.velocities` the user can input either an `{x: , y: , z: }` velocity object (applied to all mesh objects) or an array of such object (applied to each individual mesh object).