### PR TITLE
Add missing SphereGeometry parameters

### DIFF
--- a/src/geometries/SphereGeometry.ts
+++ b/src/geometries/SphereGeometry.ts
@@ -5,6 +5,10 @@ export const props = {
   radius: { type: Number, default: 1 },
   widthSegments: { type: Number, default: 12 },
   heightSegments: { type: Number, default: 12 },
+  phiStart: { type: Number, default: 0 },
+  phiLength: { type: Number, default: Math.PI * 2 },
+  thetaStart: { type: Number, default: 0 },
+  thetaLength: { type: Number, default: Math.PI },
 } as const
 
 export function createGeometry(comp: any): SphereGeometry {

--- a/src/geometries/SphereGeometry.ts
+++ b/src/geometries/SphereGeometry.ts
@@ -12,7 +12,7 @@ export const props = {
 } as const
 
 export function createGeometry(comp: any): SphereGeometry {
-  return new SphereGeometry(comp.radius, comp.widthSegments, comp.heightSegments)
+  return new SphereGeometry(comp.radius, comp.widthSegments, comp.heightSegments, comp.phiStart, comp.phiLength, comp.thetaStart, comp.thetaLength)
 }
 
 export default geometryComponent('SphereGeometry', props, createGeometry)


### PR DESCRIPTION
Noticed I couldn't use theta & phi Start/Length, which are parameters on the `SphereGeometry`.

I couldn't seem to test it properly though. The build process isn't very clear (at least, the usage of it locally isn't, I'm using it as a Vue plugin in another project). If that were more clear to me, I'd love to go over the existing Geos, and also add the other missing definition classes.

Edit: I _was_ able to test it when running vite from within this repo. Added comp.* definitions as a result.

![PhiStartLength](https://user-images.githubusercontent.com/245041/150624713-190f3fe4-2ae0-476f-809e-b598436531d8.gif)
