### PR TITLE
Upgrade three@138 and devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "node:17",
+  "features": {
+    "git": "latest"
+  },"extensions": [
+    "johnsoncodehk.volar",
+  ],
+  "forwardPorts": [3000]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^3.0.0",
-    "@types/three": "^0.136.0",
+    "@types/three": "^0.138.0",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "@vitejs/plugin-vue": "^2.2.0",
@@ -27,7 +27,7 @@
     "rollup-plugin-dts": "^4.0.0",
     "rollup-plugin-esbuild": "^4.1.0",
     "stats.js": "0.17.0",
-    "three": "^0.136.0",
+    "three": "^0.138.3",
     "typescript": "^4.1.5",
     "vite": "^2.6.13",
     "vue": "^3.2.20",

--- a/src/components/meshes/Gem.js
+++ b/src/components/meshes/Gem.js
@@ -5,7 +5,7 @@ import {
   FrontSide,
   LinearMipmapLinearFilter,
   Mesh as TMesh,
-  RGBFormat,
+  RGBAFormat,
   WebGLCubeRenderTarget,
 } from 'three'
 
@@ -32,7 +32,7 @@ export default defineComponent({
   },
   methods: {
     initGem() {
-      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { format: RGBFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
+      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { format: RGBAFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
       this.cubeCamera = new CubeCamera(this.cubeCameraNear, this.cubeCameraFar, cubeRT)
       bindProp(this, 'position', this.cubeCamera)
       this.addToParent(this.cubeCamera)

--- a/src/components/meshes/MirrorMesh.js
+++ b/src/components/meshes/MirrorMesh.js
@@ -2,7 +2,7 @@ import { defineComponent } from 'vue'
 import {
   CubeCamera,
   LinearMipmapLinearFilter,
-  RGBFormat,
+  RGBAFormat,
   WebGLCubeRenderTarget,
 } from 'three'
 
@@ -27,7 +27,7 @@ export default defineComponent({
   },
   methods: {
     initMirrorMesh() {
-      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { format: RGBFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
+      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { format: RGBAFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
       this.cubeCamera = new CubeCamera(this.cubeCameraNear, this.cubeCameraFar, cubeRT)
       this.addToParent(this.cubeCamera)
 

--- a/src/components/meshes/RefractionMesh.js
+++ b/src/components/meshes/RefractionMesh.js
@@ -3,7 +3,7 @@ import {
   CubeCamera,
   CubeRefractionMapping,
   LinearMipmapLinearFilter,
-  RGBFormat,
+  RGBAFormat,
   WebGLCubeRenderTarget,
 } from 'three'
 
@@ -29,7 +29,7 @@ export default defineComponent({
   },
   methods: {
     initMirrorMesh() {
-      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { mapping: CubeRefractionMapping, format: RGBFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
+      const cubeRT = new WebGLCubeRenderTarget(this.cubeRTSize, { mapping: CubeRefractionMapping, format: RGBAFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
       this.cubeCamera = new CubeCamera(this.cubeCameraNear, this.cubeCameraFar, cubeRT)
       bindProp(this, 'position', this.cubeCamera)
       this.addToParent(this.cubeCamera)

--- a/src/core/CubeCamera.ts
+++ b/src/core/CubeCamera.ts
@@ -1,5 +1,5 @@
 import { defineComponent, inject, onUnmounted, PropType } from 'vue'
-import { CubeCamera, LinearMipmapLinearFilter, Mesh, RGBFormat, WebGLCubeRenderTarget } from 'three'
+import { CubeCamera, LinearMipmapLinearFilter, Mesh, RGBAFormat, WebGLCubeRenderTarget } from 'three'
 import Object3D from './Object3D'
 import { RendererInjectionKey } from './Renderer'
 
@@ -26,7 +26,7 @@ export default defineComponent({
     }
 
     const renderer = rendererC.renderer, scene = rendererC.scene
-    const cubeRT = new WebGLCubeRenderTarget(props.cubeRTSize, { format: RGBFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
+    const cubeRT = new WebGLCubeRenderTarget(props.cubeRTSize, { format: RGBAFormat, generateMipmaps: true, minFilter: LinearMipmapLinearFilter })
     const cubeCamera = new CubeCamera(props.cubeCameraNear, props.cubeCameraFar, cubeRT)
     const updateRT = () => {
       props.hideMeshes.forEach(m => { m.visible = false })


### PR DESCRIPTION
Here is a fix for #124 about the breaking RGBFormat -> RGBAFormat change in [three@137](https://github.com/mrdoob/three.js/releases/tag/r137)

I updated the three dependency package version and renamed all `RGBFormat` occurrences to `RGBAFormat`

To make my life easier, I also created a `devcontainer.json` file to not have to mess with any dependencies and installation and thought it could come in handy for other people
(the docker image I chose is the official [node:17](https://hub.docker.com/_/node) and configured the `devcontainer.json` to install git and the volar extension)

- [x] It correctly builds the vue app and runs without any errors (using `yarn dev` and `yarn build` )
- [x] It correctly builds the package and I successfully imported it into another project of mine running three@138.3 (using `yarn rollup`)
- [x] didn't find any tests to run, let me know if I missed them, I'll gladly run them if needed

Thanks a lot for creating troisJS!
Let me know if I should split the pull request or if you aren't keen on the `devcontainer.json`