### PR TITLE
ISSUE(effects/unreal-bloom): Removed undefined uniform in callback for watcher

### DIFF
--- a/src/effects/UnrealBloomPass.ts
+++ b/src/effects/UnrealBloomPass.ts
@@ -20,7 +20,7 @@ export default defineComponent({
 
     Object.keys(props).forEach(p => {
       // @ts-ignore
-      watch(() => this[p], (value) => { pass.uniforms[p].value = value })
+      watch(() => this[p], (value) => { pass[p].value = value })
     })
 
     this.initEffectPass(pass)


### PR DESCRIPTION
There were no uniforms in UnrealBloomPass, so this will cause an error when updating the props