### PR TITLE
DRACO loader support

### DIFF
--- a/src/models/GLTF.ts
+++ b/src/models/GLTF.ts
@@ -1,11 +1,20 @@
 import { defineComponent } from 'vue'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
 import Model from './Model'
 
 export default defineComponent({
   extends: Model,
+  props: {
+    dracoPath: { type: String, required: true },
+  },
   created() {
     const loader = new GLTFLoader()
+    if (this.dracoPath) {
+      const dracoLoader = new DRACOLoader()
+      dracoLoader.setDecoderPath(this.dracoPath)
+      loader.setDRACOLoader(dracoLoader)
+    }
     this.$emit('before-load', loader)
     loader.load(this.src, (gltf) => {
       this.onLoad(gltf)


### PR DESCRIPTION
hey, first of all **THANK YOU** for this awesome library!

here's a PR to support [DRACOLoader](https://threejs.org/docs/#examples/en/loaders/DRACOLoader) to load compressed GLTF models. at the moment they fail to load, and the current implementation of Trois doesn't allow to access the GLTFLoader before actually loading the file afaik

it allows tu use much lighter models, and is the default compression algorithm when exporting models with blender, so I believe it's a rather common use case

I've done everything in this PR to blend in the rest of the code, but feel free to let me know if you see something you dislike

you can check out [this branch of my repo](https://github.com/kartsims/trois/tree/draco-test) if you want an implementation example (I included test files and usage)