### PR TITLE
Fixing tiny typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ TroisJS is really simple and easy to use :
         box.rotation.x += 0.01;
       });
     }
-  }).mount('#app');;
+  }).mount('#app');
 </script>
 ```
 


### PR DESCRIPTION
Hello and thank you for this great repo!

Just noticed an extra semicolon in the example code inside README.