### PR TITLE
TubeGeometry radial segments property bug

### DIFF
--- a/src/geometries/TubeGeometry.ts
+++ b/src/geometries/TubeGeometry.ts
@@ -20,7 +20,7 @@ export function createGeometry(comp: any): TubeGeometry {
   } else {
     console.error('Missing path curve or points.')
   }
-  return new TubeGeometry(curve, comp.tubularSegments, comp.radius, comp.radiusSegments, comp.closed)
+  return new TubeGeometry(curve, comp.tubularSegments, comp.radius, comp.radialSegments, comp.closed)
 }
 
 export default defineComponent({


### PR DESCRIPTION
TubeGeometry's `radialSegments` prop is not passed correctly due to a typo.